### PR TITLE
Replace $container `has` check with `hasParameter`

### DIFF
--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -144,7 +144,7 @@ final class SonataAdminExtension extends Extension
 
                 break;
             case 'sonata.admin.security.handler.acl':
-                if (!$container->has('security.acl.provider')) {
+                if (!$container->hasParameter('security.acl.provider')) {
                     throw new \RuntimeException(
                         'The "security.acl.provider" service is needed to use ACL as security handler.'
                         .' You MUST install and enable the "symfony/acl-bundle" bundle.'


### PR DESCRIPTION
When extensions are being loaded one by one into tmpContainer inside
`vendor/symfony/dependency-injection/Compiler/MergeExtensionConfigurationPass.php`
`sonata_admin` configuration is loaded alone, and other extension services are not present.
By replacing `has` check with `hasParameter` check we can make sure parameter exists instead of service.
Since we can easily configure extra parameter,
but to get service we would need to load most of the acl bundle extension services.
